### PR TITLE
fix: correção do spacing do grid e dividir em dois componentes

### DIFF
--- a/client/src/components/groups/GroupCard.js
+++ b/client/src/components/groups/GroupCard.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Paper from '../ui/Paper'
+import Button from '../ui/Button'
+import { Link } from 'react-router-dom'
+import styled from 'styled-components'
+
+const GroupCover = styled.div`
+  width: 100%;
+  height:170px;
+  background: url('${props => props.cover}');
+  background-size:cover;
+  background-position:center
+`
+
+const GroupInfo = styled.div`
+  padding:20px;
+  h4 { margin-bottom:5px;}
+  a { 
+    text-decoration:none; 
+    color: ${props => props.theme.pallete.text.primary};
+  }
+  span { 
+    text-decoration:none; 
+    color: ${props => props.theme.pallete.text.secondary}; 
+    display:block;
+    margin-bottom:15px;
+  }
+`
+
+const GroupCard = () => {
+  return (
+    <Paper>
+      <Link to="/groups/id">
+      <GroupCover cover="https://www.outraestacao.com/wp-content/uploads/2019/04/significado_bandeira_rio_grande_do_sul.jpg" />
+      </Link>
+      <GroupInfo>
+        <h4><Link to="/groups/id">Anarco Bagualismo</Link></h4>
+        <span>11 mil membros</span>
+        <Button fullwidth variant="outlined" disableElevation>Entrar</Button>
+      </GroupInfo>
+    </Paper>
+  )
+}
+
+export default GroupCard

--- a/client/src/components/library/LastItemsWidget.js
+++ b/client/src/components/library/LastItemsWidget.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Card from '../ui/Card'
+import CardHeader from '../ui/CardHeader'
+import CardBody from '../ui/CardBody'
+
+const LastItemsWidget = props => {
+  return (
+    <Card>
+      <CardHeader>
+        <h3>Contribuições Recentes</h3>
+      </CardHeader>
+      <CardBody>
+        Teste
+      </CardBody>
+    </Card>
+  )
+}
+
+export default LastItemsWidget

--- a/client/src/components/template/Search.js
+++ b/client/src/components/template/Search.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {memo} from "react";
 import styled from "styled-components";
 
 // Icons
@@ -60,4 +60,4 @@ const Search = () => {
   );
 };
 
-export default Search;
+export default memo(Search);

--- a/client/src/components/ui/Grid.js
+++ b/client/src/components/ui/Grid.js
@@ -1,15 +1,14 @@
-import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import clsx from "clsx";
 
+// This file only provides basic functionality that is common to all grid components.
+// It is NOT a component and can be moved to another folder in future.
 // This implementation aims to be close to Bootstrap's grid layout implemenation
 // and the structure is very similar to Material UI's one.
+// The main differences are that the grid is split between two components and every class is already
+// defined. Each one is applied conditionally instead of also being generated dynamically on component mount.
 // see https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Grid/Grid.js Material UI's Grid component implementation
 // see https://github.com/twbs/bootstrap/blob/8fccaa2439e97ec72a4b7dc42ccc1f649790adb0/dist/css/bootstrap-grid.css Bootstrap's CSS grid implementation
-
-// Breakpoint keys
-//const BREAKPOINTS = ["xs", "sm", "md", "lg", "xl"];
 
 // For spacing properties
 const SPACING_LEVELS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -20,7 +19,7 @@ const SIZING_LEVEL_NUMBER = SIZING_LEVELS.length - 2;
 const COMMON_BREAKPOINTS_PROPTYPE = [...SIZING_LEVELS, false];
 
 // Prop types for both container and item components
-const commonPropTypes = {
+export const commonPropTypes = {
   alignContent: PropTypes.oneOf([
     "stretch",
     "center",
@@ -62,7 +61,8 @@ const commonPropTypes = {
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
 };
 
-const makeGrid = (baseStyles = ``, breakpoint) => {
+const makeGrid = breakpoint => {
+  let baseStyles = ``;
   let jss = ``;
   SIZING_LEVELS.forEach(sizing => {
     const classKey = `grid-${breakpoint}-${sizing}`;
@@ -101,7 +101,7 @@ const makeGrid = (baseStyles = ``, breakpoint) => {
       baseStyles += `@media only screen and (min-width: 601px) and (max-width: 1279px) { ${jss} }`;
     } else if (breakpoint === "lg") {
       // large is from 961px to 1919px
-      baseStyles += `@media only screen and (min-width: 961px) and (max-width: 1919px) { ${jss} }`;
+      baseStyles += `@media only screen and (min-width: 1280px) and (max-width: 1919px) { ${jss} }`;
     } else if (breakpoint === "xl") {
       // extra large is from 1920px and above
       baseStyles += `@media only screen and (min-width: 1920px) { ${jss} }`;
@@ -134,8 +134,11 @@ const makeSpacing = breakpoint => {
 
     jss += `
     .spacing-${breakpoint}-${spacing} {
-      margin: -${offset(spacing, 2)};
-      width: calc(100% + ${offset(spacing)});
+      margin: -${offset(currentSpacing, 2)};
+      width: calc(100% + ${offset(currentSpacing)});
+      & > .item {
+        padding: ${offset(currentSpacing, 2)};
+      }
     }
     `;
   });
@@ -143,9 +146,9 @@ const makeSpacing = breakpoint => {
   return jss;
 };
 
-const commonStyles = props => `
+export const commonStyles = props => `
   /* handle flex direction */
-  ${!props.direction ? "flex-direction: row" : ""};
+  ${!props.flexDirection ? "flex-direction: row" : ""};
   & > .direction-xs-column { flex-direction: column; }
   & > .direction-xs-column-reverse { flex-direction: column-reverse; }
   & > .direction-xs-row-reverse { flex-direction: row-reverse; }
@@ -154,7 +157,7 @@ const commonStyles = props => `
   & > .zeroMinWidth { min-width: 0; }
   
   /* handle nowrap */
-  flex-wrap: ${props.wrap};
+  flex-wrap: ${props.flexWrap};
   
   /* handle align-items */
   & > .align-items-xs-stretch { align-items: stretch; }
@@ -182,26 +185,26 @@ const commonStyles = props => `
   ${makeSpacing("xs")}
 
   /* generate grids for each breakpoint */
-  ${makeGrid(``, "xs")}
-  ${makeGrid(``, "sm")}
-  ${makeGrid(``, "md")}
-  ${makeGrid(``, "lg")}
-  ${makeGrid(``, "xl")}
+  ${makeGrid("xs")}
+  ${makeGrid("sm")}
+  ${makeGrid("md")}
+  ${makeGrid("lg")}
+  ${makeGrid("xl")}
 
 `;
 
-const propertyDefault = (prop, defaultValue) => {
+export const propertyDefault = (prop, defaultValue) => {
   if (prop === undefined) {
     return defaultValue;
   } else return prop;
 };
 
-const generateClassNames = props => {
+export const generateClassNames = props => {
   const classNames = clsx({
     zeroMinWidth: props.zeroMinWidth,
     [`spacing-xs-${props.spacing}`]: props.spacing !== 0,
-    [`direction-xs-${props.direction}`]: props.direction !== "row",
-    [`wrap-xs-${props.wrap}`]: props.wrap !== "wrap",
+    [`direction-xs-${props.flexDirection}`]: props.flexDirection !== "row",
+    [`wrap-xs-${props.flexWrap}`]: props.flexWrap !== "wrap",
     [`align-items-xs-${props.alignItems}`]: props.alignItems !== "stretch",
     [`align-content-xs-${props.alignContent}`]:
       props.alignContent !== "stretch",
@@ -214,82 +217,4 @@ const generateClassNames = props => {
     [`grid-xl-${props.xl}`]: props.xl !== false
   });
   return classNames;
-};
-
-const GridContainerWrapper = styled.div`
-  display: flex;
-  ${props => commonStyles(props)}
-  box-sizing: border-box;
-  width: 100%;
-`;
-
-GridContainerWrapper.propTypes = commonPropTypes;
-
-const GridItemWrapper = styled.div`
-  display: flex;
-  ${props => commonStyles(props)}
-  box-sizing: border-box;
-  margin: 0;
-`;
-
-GridItemWrapper.propTypes = commonPropTypes;
-
-export const GridContainer = props => {
-  // default prop values:
-  let newProps = {
-    alignContent: propertyDefault(props.alignContent, "stretch"),
-    alignItems: propertyDefault(props.alignItems, "stretch"),
-    direction: propertyDefault(props.direction, "row"),
-    justifyContent: propertyDefault(props.justifyContent, "flex-start"),
-    xs: propertyDefault(props.xs, false),
-    sm: propertyDefault(props.sm, false),
-    md: propertyDefault(props.md, false),
-    lg: propertyDefault(props.lg, false),
-    xl: propertyDefault(props.xl, false),
-    spacing: propertyDefault(props.spacing, 0),
-    wrap: propertyDefault(props.wrap, "wrap"),
-    zeroMinWidth: propertyDefault(props.zeroMinWidth, false)
-  };
-
-  Object.preventExtensions(newProps);
-
-  return (
-    <GridContainerWrapper
-      {...newProps}
-      style={props.style}
-      className={generateClassNames(newProps)}
-    >
-      {props.children}
-    </GridContainerWrapper>
-  );
-};
-
-export const GridItem = props => {
-  // default prop values:
-  let newProps = {
-    alignContent: propertyDefault(props.alignContent, "stretch"),
-    alignItems: propertyDefault(props.alignItems, "stretch"),
-    direction: propertyDefault(props.direction, "row"),
-    justifyContent: propertyDefault(props.justifyContent, "flex-start"),
-    xs: propertyDefault(props.xs, false),
-    sm: propertyDefault(props.sm, false),
-    md: propertyDefault(props.md, false),
-    lg: propertyDefault(props.lg, false),
-    xl: propertyDefault(props.xl, false),
-    spacing: propertyDefault(props.spacing, 0),
-    wrap: propertyDefault(props.wrap, "wrap"),
-    zeroMinWidth: propertyDefault(props.zeroMinWidth, false)
-  };
-
-  Object.preventExtensions(newProps);
-
-  return (
-    <GridItemWrapper
-      {...newProps}
-      style={props.style}
-      className={generateClassNames(newProps)}
-    >
-      {props.children}
-    </GridItemWrapper>
-  );
 };

--- a/client/src/components/ui/GridContainer.js
+++ b/client/src/components/ui/GridContainer.js
@@ -1,0 +1,49 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  propertyDefault,
+  commonPropTypes,
+  generateClassNames,
+  commonStyles
+} from "./Grid";
+
+const GridContainerWrapper = styled.div`
+  display: flex;
+  ${props => commonStyles(props)}
+  box-sizing: border-box;
+  width: 100%;
+`;
+
+GridContainerWrapper.propTypes = commonPropTypes;
+
+const GridContainer = props => {
+  // default prop values:
+  let newProps = {
+    alignContent: propertyDefault(props.alignContent, "stretch"),
+    alignItems: propertyDefault(props.alignItems, "stretch"),
+    flexDirection: propertyDefault(props.flexDirection, "row"),
+    justifyContent: propertyDefault(props.justifyContent, "flex-start"),
+    xs: propertyDefault(props.xs, false),
+    sm: propertyDefault(props.sm, false),
+    md: propertyDefault(props.md, false),
+    lg: propertyDefault(props.lg, false),
+    xl: propertyDefault(props.xl, false),
+    spacing: propertyDefault(props.spacing, 0),
+    flexWrap: propertyDefault(props.flexWrap, "wrap"),
+    zeroMinWidth: propertyDefault(props.zeroMinWidth, false)
+  };
+
+  Object.preventExtensions(newProps);
+
+  return (
+    <GridContainerWrapper
+      {...newProps}
+      style={props.style}
+      className={generateClassNames(newProps)}
+    >
+      {props.children}
+    </GridContainerWrapper>
+  );
+};
+
+export default GridContainer;

--- a/client/src/components/ui/GridItem.js
+++ b/client/src/components/ui/GridItem.js
@@ -1,0 +1,57 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  propertyDefault,
+  commonPropTypes,
+  generateClassNames,
+  commonStyles
+} from "./Grid";
+
+const GridItemWrapper = styled.div`
+  display: flex;
+  ${props => commonStyles(props)}
+  box-sizing: border-box;
+  margin: 0;
+`;
+
+GridItemWrapper.propTypes = commonPropTypes;
+
+const GridItem = props => {
+  // default prop values:
+  let newProps = {
+    alignContent: propertyDefault(props.alignContent, "stretch"),
+    alignItems: propertyDefault(props.alignItems, "stretch"),
+    flexDirection: propertyDefault(props.direction, "row"),
+    justifyContent: propertyDefault(props.justifyContent, "flex-start"),
+    xs: propertyDefault(props.xs, false),
+    sm: propertyDefault(props.sm, false),
+    md: propertyDefault(props.md, false),
+    lg: propertyDefault(props.lg, false),
+    xl: propertyDefault(props.xl, false),
+    /**
+     *  You absolutely CAN put spacing in grid items, but it's NOT recommended.
+     *  Put spacing  in the container instead.
+     */
+    spacing: propertyDefault(props.spacing, 0),
+    /**
+     * Using 'nowrap' is not recommended as it can cause flow issues and
+     * some weird bugs, but it's up to you
+     */
+    flexWrap: propertyDefault(props.wrap, "wrap"),
+    zeroMinWidth: propertyDefault(props.zeroMinWidth, false)
+  };
+
+  Object.preventExtensions(newProps);
+
+  return (
+    <GridItemWrapper
+      {...newProps}
+      style={props.style}
+      className={`${generateClassNames(newProps)} item`}
+    >
+      {props.children}
+    </GridItemWrapper>
+  );
+};
+
+export default GridItem;

--- a/client/src/components/ui/Hero.js
+++ b/client/src/components/ui/Hero.js
@@ -7,6 +7,8 @@ const HeroWrapper = styled.div`
   background: ${ props => props.theme.pallete.paper };
   padding: 40px 30px;
   margin-top: 15px;
+  display:flex;
+  justify-content:space-between;
 
   > h2 { 
     font-size:30px;
@@ -14,10 +16,16 @@ const HeroWrapper = styled.div`
   }
 `;
 
-const Hero = ({ title, description }) => (
+const Hero = ({ title, description, actions }) => (
   <HeroWrapper>
-    <h2>{title}</h2>
-    <p>{description}</p>
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+    </div>
+
+    <div>
+      {actions}
+    </div>
   </HeroWrapper>
 );
 

--- a/client/src/components/ui/Tab.js
+++ b/client/src/components/ui/Tab.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+const Tab = styled.li`
+  list-style: none;
+  border-bottom: 3px solid transparent;
+
+  &:hover {
+    border-bottom: 3px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .current {
+    border-bottom: 3px solid ${props => props.theme.pallete.secondary};
+  }
+  > a {
+    display: block;
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+  }
+`;
+
+export default Tab

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -18,6 +18,7 @@
   "common.about": "About",
   "common.collection": "Collection",
   "common.contributions": "Contributions",
+  "common.search": "Search",
   "common.authors": "Author",
   "common.groups": "Groups",
   "common.categories": "Categories",

--- a/client/src/pages/feed/index.js
+++ b/client/src/pages/feed/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import Container from "../../components/ui/Container";
 import PostForm from "../../components/posts/PostForm";
 import PostCard from "../../components/posts/PostCard";
-
+import LastItemsWidget from '../../components/library/LastItemsWidget'
 export default props => (
   <Container>
     <div style={{ display: "grid", gridTemplateColumns: "auto 300px", gap: "1em", marginTop: "15px" }}>
@@ -12,7 +12,9 @@ export default props => (
         <PostCard />
         <PostCard />
       </div>
-      <div>Sidebar</div>
+      <div>
+        <LastItemsWidget />
+      </div>
     </div>
   </Container>
 );

--- a/client/src/pages/groups/SingleGroup.js
+++ b/client/src/pages/groups/SingleGroup.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import Container from '../../components/ui/Container'
+import Paper from '../../components/ui/Paper'
+import Tab from '../../components/ui/Tab'
+import Button from '../../components/ui/Button'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+const GroupBanner = styled.div`
+  height: 200px;
+  background: url("${props => props.cover}")
+  rgba(0,0,0,.5);
+  background-size: cover;
+  background-blend-mode:overlay;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background-position:center;
+
+  h2 {
+    color: ${props => props.theme.pallete.text.primary};
+    font-size:1.9em;
+    margin-bottom:5px;
+  }
+
+  span {
+  color: ${props => props.theme.pallete.text.secondary};
+  font-size:1.1em;
+  font-weight:lighter;
+
+  }
+`
+
+const GroupMenu = styled.div`
+  width:100%;
+  background:rgba(255,255,255,0.02)
+`
+
+const SingleGroup = () => {
+  return (
+    <>
+      <GroupBanner cover="https://www.outraestacao.com/wp-content/uploads/2019/04/significado_bandeira_rio_grande_do_sul.jpg">
+        <Container>
+          <div style={{ display: 'flex', justifyContent: "space-between", alignItems: 'center' }}>
+            <div>
+              <h2>Anarco Bagualismo</h2>
+              <span>Grupo Público - 120 membros</span>
+            </div>
+            <div>
+              <Button color="secondary">SAIR</Button>
+            </div>
+          </div>
+        </Container>
+      </GroupBanner>
+
+        <GroupMenu>
+      <Container>
+          <ul style={{ display: 'flex' }}>
+            <Tab>                
+              <Link to="/user" className="current">Quadro</Link>
+            </Tab>
+            <Tab>                
+              <Link to="/user">Chat</Link>
+            </Tab>
+            <Tab>                
+              <Link to="/user">Arquivos</Link>
+            </Tab>
+            <Tab>                
+              <Link to="/user">Membros</Link>
+            </Tab>
+          </ul>
+      </Container>
+        </GroupMenu>
+    </>
+  )
+}
+
+export default SingleGroup

--- a/client/src/pages/groups/index.js
+++ b/client/src/pages/groups/index.js
@@ -1,6 +1,8 @@
 import React from "react";
 import Container from "../../components/ui/Container";
 import Hero from "../../components/ui/Hero";
+import Button from "../../components/ui/Button";
+import GroupCard from '../../components/groups/GroupCard'
 
 // i18n
 import { FormattedMessage } from "react-intl";
@@ -21,7 +23,22 @@ export default props => {
             description="Descrição da página de grupos"
           />
         }
+        actions={
+          <Button disableElevation variant="outlined">
+            Criar Grupo
+          </Button>
+        }
       />
+      <h3 style={{margin: '20px 0px 10px'}}>Explorar Grupos</h3>
+
+      <div style={{display:'grid', gridTemplateColumns: "1fr 1fr 1fr", gap: '1em'}}>
+        <GroupCard />
+        <GroupCard />
+        <GroupCard />
+        <GroupCard />
+        <GroupCard />
+        <GroupCard />
+      </div>
     </Container>
   );
 };

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -12,6 +12,7 @@ import SingleArticle from "./pages/library/articles/SingleArticle";
 import VideosOverview from "./pages/library/videos";
 import SingleVideo from "./pages/library/videos/SingleVideo";
 import Groups from "./pages/groups";
+import SingleGroup from "./pages/groups/SingleGroup";
 import Events from "./pages/events";
 import Projects from "./pages/projects";
 import Profile from "./pages/profiles";
@@ -56,6 +57,10 @@ export default ({ auth }) => {
       exact: true,
       path: "/groups",
       component: Groups
+    },
+    {
+      path: "/groups/:id",
+      component: SingleGroup
     },
     {
       exact: true,


### PR DESCRIPTION
Essa PR contém correções para o componente de grid, que agora é dividido em dois arquivos e mantém o arquivo **Grid.js** com funcionalidade comum aos dois componentes principais.

Algumas outras alterações:
- a propriedade _direction_ agora é _flexDirection_
- a propriedade _wrap_ agora é _flexWrap_
- o spacing recomendavelmente deve ser aplicado **apenas no container**